### PR TITLE
[1/1] update build command to get current repo URL from remote

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -8,7 +8,8 @@ const targets: Record<string, Bun.Build.Target> = {
 
 const gitCommit = await $`git rev-parse HEAD`.text();
 const buildTime = new Date().toISOString();
-const remoteUrl = await $`git config --get remote.origin.url`.text();
+const remoteUrl =
+  await $`git config --get remote.origin.url | sed -e 's/:/\//g'| sed -e 's/ssh\/\/\///g'| sed -e 's/git@/https:\/\//g'`.text();
 const repoUrl = await Bun.fetch(remoteUrl).then((response) => response.url);
 
 const stringifyValues = (obj: Record<string, string>) => {


### PR DESCRIPTION
**Stack:**

* https://github.com/NDC-Tourney/stream-overlay/pull/39


---

update build command to get current repo URL from remote

did not work with SSH remotes

Change-Id: If9592106a5fd58b2eac74027e60baea51136578e

