### PR TITLE
add workaround for Bun.build HTML caching issue

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import type { JSONType } from "node_modules/zod/v4/core/util.d.cts";
 // import bunPluginTailwind from "bun-plugin-tailwind";
 
 const targets: Record<string, Bun.Build.Target> = {
@@ -6,16 +7,22 @@ const targets: Record<string, Bun.Build.Target> = {
   linux: "bun-linux-x64",
 };
 
-const gitCommit = await $`git rev-parse HEAD`.text();
-const buildTime = new Date().toISOString();
+const buildTime = Date.now();
+const buildTimeEtag = buildTime.toString(36);
+console.log("build time:", new Date(buildTime), buildTime);
+
+const gitCommit = await $`git rev-parse HEAD`.text().then((s) => s.trim());
+console.log("git commit:", gitCommit);
+
 const remoteUrl =
   await $`git config --get remote.origin.url | sed -e 's/:/\//g'| sed -e 's/ssh\/\/\///g'| sed -e 's/git@/https:\/\//g'`.text();
 const repoUrl = await Bun.fetch(remoteUrl).then((response) => response.url);
+console.log("repo URL:", repoUrl);
 
-const stringifyValues = (obj: Record<string, string>) => {
-  const newObj: typeof obj = {};
+const stringifyValues = (obj: Record<string, JSONType>) => {
+  const newObj: Record<string, string> = {};
   for (const key in obj) {
-    newObj[key] = JSON.stringify(obj[key]?.trim());
+    newObj[key] = JSON.stringify(obj[key]);
   }
   return newObj;
 };
@@ -29,6 +36,7 @@ for (const [platform, target] of Object.entries(targets)) {
     define: stringifyValues({
       "process.env.NODE_ENV": "production",
       BUILD_TIME: buildTime,
+      BUILD_TIME_ETAG: buildTimeEtag,
       GIT_COMMIT: gitCommit,
       REPO_URL: repoUrl,
     }),


### PR DESCRIPTION
add workaround for Bun.build HTML caching issue

Bun.build does not seem to change the etag header of HTML files when changing the hash part of asset filenames inside that HTML file because the content of the original HTML file (before injecting the asset URLs) didn't change. Because of this the browser loads the cached HTML file and tries to load the old assets, which lead to 404s.

as a workaround we just inject the current unix timestamp at buildtime converted to base 36 (to make it a short string like "mfqidl1z") as the etag for HTML files (we know they won't change after building).

As previously reported [here](https://discord.com/channels/912031225894539264/1217525540660183241/1413927866982207678)
