### PR TITLE
add supporters overview

### DIFF
--- a/src/Startscreen.tsx
+++ b/src/Startscreen.tsx
@@ -9,6 +9,10 @@ import { MainContent } from "./components/MainContent";
 import { FooterContent } from "./components/FooterContent";
 import Countdown, { zeroPad } from "react-countdown";
 import { useSettings } from "./state/dashboard";
+import { PlayerCard } from "./components/PlayerCard";
+import { PlayerAvatar } from "./components/PlayerAvatar";
+import { getAvatarUrl } from "./util";
+import SupportersAvatars from "./components/SupportersAvatars";
 
 interface StartScreenProps {
   from?: string;
@@ -16,16 +20,14 @@ interface StartScreenProps {
 }
 
 const renderer = ({
-  hours,
   minutes,
   seconds,
 }: {
-  hours: number;
   minutes: number;
   seconds: number;
 }) => (
   <span>
-    {zeroPad(hours)}:{zeroPad(minutes)}:{zeroPad(seconds)}
+    {zeroPad(minutes)}:{zeroPad(seconds)}
   </span>
 );
 
@@ -54,54 +56,30 @@ export function StartScreen({ from, to }: StartScreenProps) {
               <div id="ss-stage-name">{match.roundName}</div>
               <div id="ss-winner-loser">({match.bracket} Bracket)</div>
             </div>
-            <div id="ss-upcoming">UPCOMING</div>
-
             <div id="ss-vs">
-              <div id="ss-red-player">
-                <div id="ss-red-player-icon">
-                  <img src={player1.avatarUrl} />
-                </div>
-                <div id="ss-player-info" className="align-right">
-                  <div id="ss-player-name">{player1.name}</div>
-                  <div id="ss-player-seed">Seed: {player1.seed}</div>
-                  <div id="ss-player-supporters">
-                    Supporters: {player1.supporters}
-                  </div>
-                  <div id="ss-player-pickems">
-                    Pickems: {player1.pickemsRate}%
-                  </div>
-                </div>
-              </div>
-
-              <div id="ss-vs-text">VS</div>
-
-              <div id="ss-blue-player">
-                <div id="ss-blue-player-icon">
-                  <img src={player2.avatarUrl} />
-                </div>
-                <div id="ss-player-info">
-                  <div id="ss-player-name">{player2.name}</div>
-                  <div id="ss-player-seed">Seed: {player2.seed}</div>
-                  <div id="ss-player-supporters">
-                    Supporters: {player2.supporters}
-                  </div>
-                  <div id="ss-player-pickems">
-                    Pickems: {player2.pickemsRate}%
-                  </div>
-                </div>
-              </div>
+              <PlayerCard player={player1} side="red" />
+              <div className="ss-vs-text">VS</div>
+              <PlayerCard player={player2} side="blue" />
             </div>
-            {settings.countdown && (
-              <div id="ss-time-to-start">
-                Time to start:{" "}
-                <Countdown
-                  key={`countdown-${Number(settings.countdown)}`}
-                  renderer={renderer}
-                  date={settings.countdown}
-                  autoStart={true}
-                />
+            <div id="ss-middle">
+              <SupportersAvatars player={player1} side="red" reverse={true} />
+              <div>
+                {settings.countdown && (
+                  <div className="ss-time-to-start">
+                    <span>Time to start: </span>
+                    <span className="ss-countdown">
+                      <Countdown
+                        key={`countdown-${settings.countdown.getTime()}`}
+                        renderer={renderer}
+                        date={settings.countdown}
+                        autoStart={true}
+                      />
+                    </span>
+                  </div>
+                )}
               </div>
-            )}
+              <SupportersAvatars player={player2} side="blue" />
+            </div>
           </div>
         </MainContent>
       </motion.div>

--- a/src/Winner.tsx
+++ b/src/Winner.tsx
@@ -9,6 +9,7 @@ import { FooterContent } from "./components/FooterContent";
 import { useTosu } from "./state/tosu";
 import { useMatchQuery } from "@/state/huis";
 import trophy from "./static/img/trophy.png";
+import SupportersAvatars from "./components/SupportersAvatars";
 
 interface WinnerScreenProps {
   from?: string;
@@ -29,7 +30,7 @@ export function WinnerScreen({ from, to }: WinnerScreenProps) {
   const totalPoints = Math.ceil(tourney.bestOf / 2);
 
   let winner = match.player1;
-  let winnerTeam = "red";
+  let winnerTeam: "red" | "blue" = "red";
 
   if (tourney.points.left == totalPoints) {
     winner = match.player1;
@@ -62,19 +63,21 @@ export function WinnerScreen({ from, to }: WinnerScreenProps) {
                     <div id="win-player-name">
                       {winner.name !== "" ? winner.name : "Unknown player"}
                     </div>
-                    <div id="win-player-seed">Seed: {winner.seed}</div>
-                    <div id="win-player-supporters">
-                      Supporters: {winner.supporters}
-                    </div>
                     <div id="win-player-pickems">
-                      Pickems: {winner.pickemsRate}%
+                      <span className="player-info-label">Pickems: </span>
+                      {winner.pickemsRate}%
+                    </div>
+                    <div id="win-player-seed">
+                      <span className="player-info-label">Seed: </span>
+                      {winner.seed}
                     </div>
                   </div>
                 </div>
-                <div id="win-stage-info">
+                {/* <div id="win-stage-info">
                   <div id="win-stage-name">Quarter Finals</div>
                   <div id="win-winner-loser">(Winners Bracket)</div>
-                </div>
+                </div> */}
+                <SupportersAvatars player={winner} side={winnerTeam} />
               </div>
               <div id="win-right">
                 <div id="trophy">

--- a/src/components/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar.tsx
@@ -1,0 +1,23 @@
+import clsx from "clsx";
+import type { HTMLAttributes } from "react";
+
+type Props = HTMLAttributes<HTMLDivElement> & {
+  url: string;
+  color: "red" | "blue";
+  style?: "square" | "rounded";
+};
+
+export function PlayerAvatar({ url, color, style, className }: Props) {
+  return (
+    <div
+      className={clsx(
+        "ss-player-avatar",
+        color,
+        style && `ss-${style}-player-avatar`,
+        className,
+      )}
+    >
+      <img src={url} />
+    </div>
+  );
+}

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,0 +1,27 @@
+import type { Player } from "@/state/huis";
+import clsx from "clsx";
+import { PlayerAvatar } from "./PlayerAvatar";
+
+type Props = {
+  player: Player;
+  side: "red" | "blue";
+};
+
+export function PlayerCard({ player, side }: Props) {
+  return (
+    <div id={`ss-${side}-player`}>
+      <PlayerAvatar url={player.avatarUrl} color={side} />
+      <div className={clsx("ss-player-info", side === "red" && "align-right")}>
+        <div className="ss-player-name">{player.name}</div>
+        <div className="ss-player-pickems">
+          <span className="player-info-label">Pickems: </span>
+          {player.pickemsRate}%
+        </div>
+        <div className="ss-player-seed">
+          <span className="player-info-label">Seed: </span>
+          {player.seed}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PlayerInfo.tsx
+++ b/src/components/PlayerInfo.tsx
@@ -28,14 +28,17 @@ export function PlayerInfo({ playerNum }: { playerNum: 1 | 2 }) {
           <div id="player-name" className={`align-${side}`}>
             {player.name ?? "Unknown player"}
           </div>
-          <div id="player-seed" className={`align-${side}`}>
-            Seed: {player.seed}
+          <div id="player-pickems" className={`align-${side}`}>
+            <span className="player-info-label">Pickems: </span>
+            {player.pickemsRate}%
           </div>
           <div id="player-supporters" className={`align-${side}`}>
-            Supporters: {player.supporters}
+            <span className="player-info-label">Supporters: </span>
+            {player.supporters.length}
           </div>
-          <div id="player-pickems" className={`align-${side}`}>
-            Pickems: {player.pickemsRate}%
+          <div id="player-seed" className={`align-${side}`}>
+            <span className="player-info-label">Seed: </span>
+            {player.seed}
           </div>
         </div>
       </div>

--- a/src/components/SupportersAvatars.tsx
+++ b/src/components/SupportersAvatars.tsx
@@ -1,0 +1,37 @@
+import type { Player } from "@/state/huis";
+import { PlayerAvatar } from "./PlayerAvatar";
+import { getAvatarUrl } from "@/util";
+import clsx from "clsx";
+
+type Props = {
+  player: Player;
+  reverse?: boolean;
+  side: "red" | "blue";
+};
+
+export default function SupportersAvatars({
+  player,
+  reverse = false,
+  side,
+}: Props) {
+  return (
+    <div className={clsx("ss-supporters", reverse && "reverse")}>
+      <div className="ss-supporters-amount">
+        <span className="player-info-label">Supporters: </span>
+        {player.supporters.length}
+      </div>
+      <div className={clsx("ss-supporters-avatars", reverse && "reverse")}>
+        {player.supporters.map((supporter, i) => (
+          <div key={`${supporter.id}-${i}`}>
+            <PlayerAvatar
+              className="supporter"
+              url={getAvatarUrl(supporter.id)}
+              color={side}
+            />
+            <div className="ss-supporter-name">{supporter.name}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/state/huis.ts
+++ b/src/state/huis.ts
@@ -97,22 +97,32 @@ const matchSchema = z
     supporters: z.array(
       z.object({
         supported_user_id: z.number(),
+        supporter_user_id: z.number(),
+        supporter_name: z.string(),
       }),
     ),
   })
   .transform((match) => {
-    const getPlayer = (i: 1 | 2) => ({
-      name: match[`name${i}`],
-      osuId: match[`player${i}_id`],
-      seed: match[`seed${i}`],
-      avatarUrl: getAvatarUrl(match[`player${i}_id`]),
-      pickemsRate: match[`pickems_rate${i}`].toFixed(2),
-      score: match[`team${i}_score`],
-      winner: match.winner === i,
-      supporters: match["supporters"].filter(
-        (s) => s.supported_user_id === match[`player${i}_id`],
-      ).length,
-    });
+    const getPlayer = (i: 1 | 2) => {
+      const supporters = match["supporters"]
+        .map((s) => ({
+          name: s.supporter_name,
+          id: s.supporter_user_id,
+          supportingId: s.supported_user_id,
+        }))
+        .filter((s) => s.supportingId === match[`player${i}_id`]);
+
+      return {
+        name: match[`name${i}`],
+        osuId: match[`player${i}_id`],
+        seed: match[`seed${i}`],
+        avatarUrl: getAvatarUrl(match[`player${i}_id`]),
+        pickemsRate: match[`pickems_rate${i}`].toFixed(2),
+        score: match[`team${i}_score`],
+        winner: match.winner === i,
+        supporters,
+      };
+    };
 
     type Player = WithRequired<
       Partial<ReturnType<typeof getPlayer>>,
@@ -196,14 +206,14 @@ export function useMatchQuery(): WithRequired<
         name: "???",
         avatarUrl,
         seed: 0,
-        supporters: 0,
+        supporters: [],
         pickemsRate: "0.00",
       },
       player2: {
         name: "???",
         avatarUrl,
         seed: 0,
-        supporters: 0,
+        supporters: [],
         pickemsRate: "0.00",
       },
     };
@@ -219,14 +229,14 @@ export function useMatchQuery(): WithRequired<
         name: "Unknown player",
         avatarUrl,
         seed: 0,
-        supporters: 0,
+        supporters: [],
         pickemsRate: "0.00",
       },
       player2: {
         name: "Unknown player",
         avatarUrl,
         seed: 0,
-        supporters: 0,
+        supporters: [],
         pickemsRate: "0.00",
       },
     };

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -135,21 +135,18 @@ p {
   font-size: 20px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 #player-supporters {
   font-size: 20px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 #player-pickems {
   font-size: 20px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 /* Player MapWins */
@@ -577,15 +574,6 @@ p {
   text-transform: capitalize;
 }
 
-#ss-upcoming {
-  font-size: 64px;
-  font-family: BenderBlack, Helvetica, sans-serif;
-  font-weight: normal;
-  color: white;
-  text-align: center;
-  margin-top: 80px;
-}
-
 #ss-vs {
   display: flex;
   flex-direction: row;
@@ -606,26 +594,32 @@ p {
   flex-direction: row-reverse !important;
 }
 
-#ss-red-player-icon img {
+.player-info-label {
+  color: #ff962d;
+}
+
+.ss-player-avatar img {
   margin: 16px;
-  width: 240px;
   height: 240px;
+  width: 240px;
   object-fit: cover;
-  outline: 7px solid #dc1f2b;
+  outline: 7px solid var(--ss-player-color, #dc1f2b);
   outline-offset: -7px;
 }
 
-#ss-blue-player-icon img {
-  margin: 16px;
-  width: 240px;
-  height: 240px;
-  object-fit: cover;
-  outline: 7px solid #1f55dc;
-  outline-offset: -7px;
+.ss-player-avatar.blue img {
+  --ss-player-color: #1f55dc;
 }
 
-#ss-player-info {
-  margin-top: 15px;
+.ss-player-avatar.supporter img {
+  height: 120px;
+  width: 120px;
+  border-radius: 36px;
+  outline-offset: 0px;
+}
+
+.ss-player-info {
+  margin-top: 32px;
   margin-left: 20px;
   margin-right: 20px;
   display: flex;
@@ -633,50 +627,109 @@ p {
   gap: 10px;
 }
 
-#ss-player-name {
+.ss-player-name {
   font-size: 64px;
   font-family: BenderBlack, Helvetica, sans-serif;
   font-weight: normal;
   color: white;
 }
 
-#ss-player-seed {
+.ss-player-seed {
   font-size: 36px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
   color: white;
 }
 
-#ss-player-supporters {
+.ss-player-supporters {
   font-size: 36px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
   color: white;
 }
 
-#ss-player-pickems {
+.ss-player-pickems {
   font-size: 36px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
   color: white;
 }
 
-#ss-vs-text {
+#ss-middle {
+  display: grid;
+  grid-template-columns: 1fr 360px 1fr;
+}
+
+.ss-supporters {
+  font-size: 24px;
+  font-family: BenderRegular, Helvetica, sans-serif;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 36px;
+  gap: 23px;
+}
+
+.ss-supporters.reverse {
+  align-items: flex-end;
+}
+
+.ss-supporters-amount {
+  font-size: 36px;
+}
+
+.ss-supporters-avatars {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-rows: 1;
+  row-gap: 10px;
+  width: 740px;
+}
+
+/* kinda cursed but fuck iiit */
+.ss-supporters-avatars.reverse {
+  direction: rtl;
+  & > * {
+    direction: ltr;
+  }
+}
+
+.ss-supporter-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: initial;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-wrap-style: balance;
+  padding: 0 10px;
+}
+
+.ss-vs-text {
   font-size: 48px;
   font-family: BenderBlack, Helvetica, sans-serif;
   font-weight: 900;
   color: #ff962d;
 }
 
-#ss-time-to-start {
-  font-size: 64px;
+.ss-time-to-start {
+  display: flex;
+  flex-direction: column;
+  font-size: 36px;
   font-family: BenderBlack, Helvetica, sans-serif;
   font-weight: normal;
   font-variant-numeric: tabular-nums;
   color: white;
-  text-align: left;
+  text-align: center;
   padding-top: 120px;
   padding-left: 20px;
+}
+
+.ss-countdown {
+  font-size: 64px;
 }
 
 #current-status {
@@ -1048,7 +1101,7 @@ p {
 }
 
 #win-left {
-  margin-top: 200px;
+  margin-top: 120px;
   margin-left: 296px;
   width: 880px;
 }
@@ -1058,11 +1111,12 @@ p {
   font-family: BenderBlack, Helvetica, sans-serif;
   font-weight: normal;
   color: #ff962d;
+  text-transform: uppercase;
 }
 
 #win-player {
   display: flex;
-  margin-top: 20px;
+  margin-top: 28px;
 }
 
 #win-player-icon img {
@@ -1103,21 +1157,18 @@ p {
   font-size: 40px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 #win-player-supporters {
   font-size: 40px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 #win-player-pickems {
   font-size: 40px;
   font-family: BenderRegular, Helvetica, sans-serif;
   font-weight: normal;
-  color: #ff962d;
 }
 
 #win-stage-info {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2-alpha",
+  "version": "1.3-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Added supporters to the starting and winner screens. Also changed some of the styling to be more closely aligned with the designs in Figma.

I'll probably change it so that when there are more than four supporters it's like an infinitely repeating/auto-scrolling marquee type thing but that can wait for next week.

Player info header:
<img width="1925" height="156" alt="image" src="https://github.com/user-attachments/assets/c2ed32cd-4312-4528-b226-79e75e3d2a90" />
---
Starting screen:
<img width="1925" height="1087" alt="image" src="https://github.com/user-attachments/assets/5cc07445-db59-4cf9-ac12-eaf3b8805a4f" />
<img width="1925" height="1089" alt="image" src="https://github.com/user-attachments/assets/712e26da-97a5-40d4-93ad-6ee99ddc802f" />
---
Winner screen:
<img width="1925" height="1087" alt="image" src="https://github.com/user-attachments/assets/2d119bc8-e987-44a7-a8a5-75e841168083" />
<img width="1925" height="1089" alt="image" src="https://github.com/user-attachments/assets/53d776ee-451d-4f4b-a37d-a6c3a4f68aaf" />
---