### PR TITLE
fix rendering error by wrapping setState in useEffect

### DIFF
--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -17,10 +17,12 @@ export function Dashboard() {
   const autoselect = settings.automaticSelect;
 
   // default to the next upcoming match on startup
-  if (!settings.matchId && schedule.upcoming[0]) {
-    const nextMatch = schedule.upcoming[0].uid;
-    setSettings((settings) => ({ ...settings, matchId: nextMatch }));
-  }
+  useEffect(() => {
+    if (!settings.matchId && schedule.upcoming[0]) {
+      const nextMatch = schedule.upcoming[0].uid;
+      setSettings((settings) => ({ ...settings, matchId: nextMatch }));
+    }
+  }, [settings.matchId, schedule.upcoming]);
 
   const selectedMatch = useMemo(() => {
     const match = matches?.find((m) => m.uid === settings.matchId);


### PR DESCRIPTION
fix rendering error by wrapping setState in useEffect

this is normally a fine pattern but in this case it's actually calling
setState in the context provider component and not its own component
which is not supported. Idk if there's a way to avoid the useEffect call
in this case

Change-Id: Idc526a12a147b46a9a2825090a3b4e3f514df95c
