### PR TITLE
add environment variable to disable opening dashboard URL on start

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ console.log(
 const overlayUrl = server.url.toString();
 const dashboardUrl = new URL("dashboard", server.url).toString();
 
-if (isProduction) {
+if (isProduction && process.env.OPEN_DASHBOARD_URL !== "false") {
   open(dashboardUrl);
 }
 


### PR DESCRIPTION
add environment variable to disable opening dashboard URL on start

Change-Id: Ib2c451d68a372590a5e5e48bc09fb2ddd1be9a5d
<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>➡️https://github.com/NDC-Tourney/stream-overlay/pull/93</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->