### PR TITLE
fix border overlap for player icons on scheduling screen

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1276,8 +1276,8 @@ p {
 
 .match-red-player-icon,
 .match-blue-player-icon {
-  width: 67px;
-  height: 67px;
+  width: 68px;
+  height: 68px;
 }
 
 .match-red-player-icon img {
@@ -1307,8 +1307,8 @@ p {
 }
 
 .match-box {
-  width: 67px;
-  height: 67px;
+  width: 68px;
+  height: 68px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
fix border overlap for player icons on scheduling screen

Change-Id: I0c22306cee1b09476f1e63f59ca7120762f987a4
