### PR TITLE
overwrite old pick/ban selection for beatmap

### DIFF
--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -96,26 +96,28 @@ export function Dashboard() {
     }
 
     setSettings(
-      produce((prev) => {
-        const prevSelection = prev[prev.activePlayer];
-        if (!prevSelection[pickOrBan].includes(map)) {
-          prevSelection[pickOrBan].push(map);
-
-          const other = pickOrBan === "bans" ? "picks" : "bans";
-          if (prevSelection[other].includes(map)) {
-            prevSelection[other] = prevSelection[other].filter(
-              (m) => m !== map,
-            );
+      produce((settings) => {
+        const selection = settings[settings.activePlayer];
+        if (!selection[pickOrBan].includes(map)) {
+          // remove from all selections first
+          for (const player of ["player1", "player2"] as const) {
+            for (const type of ["bans", "picks"] as const) {
+              settings[player][type] = settings[player][type].filter(
+                (m) => m !== map,
+              );
+            }
           }
-        } else {
-          prevSelection[pickOrBan] = prevSelection[pickOrBan].filter(
-            (m) => m !== map,
-          );
-        }
-        prev.lastPickedBy = map.includes("TB") ? null : prev.activePlayer;
 
-        prev.activePlayer =
-          prev.activePlayer === "player1" ? "player2" : "player1";
+          selection[pickOrBan].push(map);
+        } else {
+          selection[pickOrBan] = selection[pickOrBan].filter((m) => m !== map);
+        }
+
+        settings.lastPickedBy = map.includes("TB")
+          ? null
+          : settings.activePlayer;
+        settings.activePlayer =
+          settings.activePlayer === "player1" ? "player2" : "player1";
       }),
     );
     pickOrBan === "picks"


### PR DESCRIPTION
overwrite old pick/ban selection for beatmap

Change-Id: I0c1c4645422c6dcd73e56f7b47995abe470ee5d5
<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/NDC-Tourney/stream-overlay/pull/106</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/107</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/108</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/109</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/110</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/111</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/112</li><li>➡️https://github.com/NDC-Tourney/stream-overlay/pull/113</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/114</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->