### PR TITLE
add banned/picked indicator in ban/pick dropdrown

### DIFF
--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -79,7 +79,7 @@ export function Dashboard() {
   const { beatmaps } = useMappoolQuery();
   const mappoolOptions = Object.values(beatmaps)
     .flat()
-    .map((map) => map.modBracket + map.modBracketIndex);
+    .map((map) => `${map.modBracket}${map.modBracketIndex}`);
 
   // Bans & Picks dropdown
   const [bansSelection, setBansSelection] = useState("Select");
@@ -147,6 +147,7 @@ export function Dashboard() {
         settings.showCountdown = value;
       }),
     );
+
   // Close dropdowns on outside click
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -169,6 +170,46 @@ export function Dashboard() {
     window.addEventListener("click", handleClickOutside);
     return () => window.removeEventListener("click", handleClickOutside);
   }, []);
+
+  const BannedOrPicked = ({ map }: { map: string }) => {
+    if (settings.player1.picks.includes(map)) {
+      return (
+        <>
+          {map}
+          <span style={{ color: "#dc1f2b" }}> picked</span>
+        </>
+      );
+    }
+
+    if (settings.player2.picks.includes(map)) {
+      return (
+        <>
+          {map}
+          <span style={{ color: "#2f6bff" }}> picked</span>
+        </>
+      );
+    }
+
+    if (settings.player1.bans.includes(map)) {
+      return (
+        <>
+          <s>{map}</s>
+          <span style={{ color: "#dc1f2b" }}> banned</span>
+        </>
+      );
+    }
+
+    if (settings.player2.bans.includes(map)) {
+      return (
+        <>
+          <s>{map}</s>
+          <span style={{ color: "#2f6bff" }}> banned</span>
+        </>
+      );
+    }
+
+    return map;
+  };
 
   return (
     <div id="main">
@@ -286,7 +327,7 @@ export function Dashboard() {
                     setBansOpen(false);
                   }}
                 >
-                  {opt}
+                  <BannedOrPicked map={opt} />
                 </div>
               ))}
             </div>
@@ -315,7 +356,7 @@ export function Dashboard() {
                     setPicksOpen(false);
                   }}
                 >
-                  {opt}
+                  <BannedOrPicked map={opt} />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
add banned/picked indicator in ban/pick dropdrown

Change-Id: I7adae8ebf91ccf368492f9d222bc1a2bb191dc88
<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>https://github.com/NDC-Tourney/stream-overlay/pull/106</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/107</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/108</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/109</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/110</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/111</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/112</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/113</li><li>➡️https://github.com/NDC-Tourney/stream-overlay/pull/114</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->