### PR TITLE
hotfix: unset some Tailwind styles conflicting with current styles

### DIFF
--- a/src/components/SupportersAvatars.tsx
+++ b/src/components/SupportersAvatars.tsx
@@ -3,6 +3,7 @@ import { getAvatarUrl } from "@/util";
 import clsx from "clsx";
 import { PlayerAvatar } from "./PlayerAvatar";
 import { Marquee } from "./Marquee";
+import { useCallback } from "react";
 
 type Props = {
   player: Player;
@@ -15,17 +16,20 @@ export default function SupportersAvatars({
   reverse = false,
   side,
 }: Props) {
-  const Avatars = () =>
-    player.supporters.map((supporter, i) => (
-      <div key={`${supporter.id}-${i}`}>
-        <PlayerAvatar
-          className="supporter"
-          url={getAvatarUrl(supporter.id)}
-          color={side}
-        />
-        <div className="ss-supporter-name">{supporter.name}</div>
-      </div>
-    ));
+  const Avatars = useCallback(
+    () =>
+      player.supporters.map((supporter, i) => (
+        <div key={`${supporter.id}-${i}`}>
+          <PlayerAvatar
+            className="supporter"
+            url={getAvatarUrl(supporter.id)}
+            color={side}
+          />
+          <div className="ss-supporter-name">{supporter.name}</div>
+        </div>
+      )),
+    [JSON.stringify(player.supporters)],
+  );
 
   return (
     <div className={clsx("ss-supporters", { reverse: reverse })}>

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -38,9 +38,20 @@
 
 body,
 html {
+  line-height: unset;
   padding: 0;
   margin: 0;
   -webkit-font-smoothing: antialiased;
+}
+
+img {
+  max-width: unset;
+  display: unset;
+}
+
+* {
+  box-sizing: unset;
+  border: unset;
 }
 
 body {


### PR DESCRIPTION
hotfix: unset some Tailwind styles conflicting with current styles

Change-Id: I666d11c22f90d96ed7521f8eef1650cd6babc36b
<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>➡️https://github.com/NDC-Tourney/stream-overlay/pull/119</li><li>https://github.com/NDC-Tourney/stream-overlay/pull/97</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->