### PR TITLE
set console depth in config instead of command line

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,5 @@
 plugins = ["bun-plugin-tailwind"]
 env = "PUBLIC_*"
 
+[console]
+depth = 0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.13.0",
   "type": "module",
   "scripts": {
-    "dev": "bun --hot --console-depth=0 src/main.ts",
+    "dev": "bun --hot src/main.ts",
     "start": "NODE_ENV=production bun src/main.ts",
     "build": "bun run build.ts",
     "prepare-pack:win": "vpk download github --repoUrl https://github.com/NDC-Tourney/stream-overlay -c win",


### PR DESCRIPTION
set console depth in config instead of command line

Change-Id: I78fe1613e8c58d6d7b7f79ee4835eb41476c4163
<!-- %%% BRANCHLESS STACK INFO START %%% -->
<details open><summary> Stack info:</summary>

| Stack 1 |
|-|
|<ul><li>➡️https://github.com/NDC-Tourney/stream-overlay/pull/127</li></ul>|

</details>
<!-- %%% BRANCHLESS STACK INFO END %%% -->